### PR TITLE
removed implicit {} from inatepowers target

### DIFF
--- a/_examples/boards/board_front.html
+++ b/_examples/boards/board_front.html
@@ -46,7 +46,7 @@
         name="explosion"
         speed="fast"
         range="wetland-presence,1"
-        target="blight"
+        target="{blight}"
         target-title="TARGET LAND"
         note="Destroy X (1 or more) of your {presence} in target land; {destroyed-presence} checks how many you destroyed. This Power does Damage (separately and equally) to both Invaders and {Dahan}. Ranges below can't be increased.">
         <level threshold="1-plant">
@@ -63,7 +63,7 @@
         name="explosion2"
         speed="slow"
         range="jungle-presence,2"
-        target="player-spirit"
+        target="{player-spirit}"
         target-title="TARGET"
         note="">
         <level threshold="1-plant">

--- a/_global/js/board_front.js
+++ b/_global/js/board_front.js
@@ -393,7 +393,7 @@ function parseInnatePowers(){
         }
         
         //Innate Power Target value
-        currentPowerHTML += "<innate-info-target>{"+innatePowerHTML.getAttribute("target")+"}</innate-info-target></innate-info></info-container>";
+        currentPowerHTML += "<innate-info-target>"+innatePowerHTML.getAttribute("target")+"</innate-info-target></innate-info></info-container>";
 
         if(innateHTML.length == 1){
             currentPowerHTML += "<description-container style='width:1000px !important'>";            


### PR DESCRIPTION
The implicit addition of `{` and `}` will prevent the usage of `ANY`, `COSTAL`, `INVADERS` and others.

using `any` will show the any-element