### PR TITLE
add support for text and image in innate power target

### DIFF
--- a/_examples/boards/board_front.html
+++ b/_examples/boards/board_front.html
@@ -64,7 +64,7 @@
         name="explosion2"
         speed="slow"
         range="none"
-        target="blight"
+        target="another spirit"
         target-title="TARGET">
         <level threshold="1-plant">
           1 Damage per 2 {fire} you have.

--- a/_global/js/board_front.js
+++ b/_global/js/board_front.js
@@ -408,14 +408,18 @@ function parseInnatePowers(){
         //Innate Power Target value
         var targetValue = innatePowerHTML.getAttribute("target");
         console.log(targetValue);
-        var specialLandsList = ["any", "coastal", "invaders", "inland"];
+        var specialLandsList = ["any","another", "coastal", "invaders", "inland"];
 
-        if(specialLandsList.includes(targetValue.toLowerCase())){
-            targetValue = targetValue.toUpperCase();
-            currentPowerHTML += "<innate-info-target>"+targetValue+"</innate-info-target></innate-info></info-container>";
-        } else {
-            currentPowerHTML += "<innate-info-target>{"+targetValue+"}</innate-info-target></innate-info></info-container>";
-        }
+        const transformedTarget =  targetValue.split(' ').map(part=>{
+            if(specialLandsList.includes(part.toLowerCase())){
+                part = part.toUpperCase();
+            }else   {
+                part = `{${part}}`
+            }
+            return part
+        }).join(' ')
+        
+        currentPowerHTML += "<innate-info-target>"+transformedTarget+"</innate-info-target></innate-info></info-container>";
 
         if(innateHTML.length == 1){
             currentPowerHTML += "<description-container style='width:1000px !important'>";            


### PR DESCRIPTION
currently it is not possible to have an innate power that targets `ANY Spirt`, `ANOTHER Spirit`, or other combinations of text and icon like

 ![Gift of Constancy](https://sick.oberien.de/imgs/powers/gift_of_constancy.webp). 

Double icons like 

![A Dreadful tide of scurrying flesh](https://sick.oberien.de/imgs/powers/a_dreadful_tide_of_scurrying_flesh.webp) also did not work.

This will split the attribure and transforms every single element instead of the howl string at once. This allowes for double icons.
 It also adds the word `another` to the list of special words.

![image](https://user-images.githubusercontent.com/389101/101996544-afcac680-3cd3-11eb-9e8a-836f3e1b3b49.png)

and icon text combinations

![image](https://user-images.githubusercontent.com/389101/101996554-c2450000-3cd3-11eb-984b-0a40edee19b1.png)

in theory any combination of allowed icons ;P
![image](https://user-images.githubusercontent.com/389101/101996563-e4d71900-3cd3-11eb-9872-436e3ef2b374.png)

I'm not sure about the spacing through...

-------------------------------------------------------------------

I havn't looked in that yet but it could make sense to combine the method with that of cards. after all every target that can be used with for a power card may also be used for a innate power.

_______________________________________________________

I haven't looked at all cards, but I guess there are some more words that would need excluding from transformation to icons. A more flexible but more inconvinient approach would to have a list of all words that can be put in `{}`. 
