### PR TITLE
Tweaks & cleanups to adversary css

### DIFF
--- a/_global/css/adversary.css
+++ b/_global/css/adversary.css
@@ -114,7 +114,7 @@ adversary-levels{
   position:absolute;
   left:35px;
   top:157px;
-  height:347px;
+  height:350px;
   width:726px;
 
   font-family: 'JosefinSans-Regular';
@@ -182,7 +182,7 @@ adversary-levels level div:last-child{
 }
 
 adversary-levels line{
-  height:1px;
+  height:0.5px; /* half pixel is intentional - when it is scaled it, it will still be one pixel wide. Was having issues with some lines being two pixels wide and some just one */
   background-color:black;
 }
 
@@ -230,7 +230,7 @@ icon.presence{
 }
 
 adversary-levels icon.city{
-  margin-top:-2px;
+  margin-top:-6px;
 }
 
 icon.town{


### PR DESCRIPTION
These small tweaks improve the rendering of the adversary. Lines will appear as a single pixel more frequently (instead of occasionally being 1 or 2 pixels, depending on zoom level). Cities don't push the text line above them as much.